### PR TITLE
Disabled wan_check service

### DIFF
--- a/repack-squashfs.sh
+++ b/repack-squashfs.sh
@@ -78,7 +78,6 @@ chown root:root "$FSDIR/sbin/xqflash"
 for SVC in stat_points statisticsservice \
 		datacenter \
 		smartcontroller \
-		wan_check \
 		plugincenter plugin_start_script.sh cp_preinstall_plugins.sh; do
 	rm -f $FSDIR/etc/rc.d/[SK]*$SVC
 done
@@ -88,7 +87,9 @@ for f in StatPoints mtd_crash_log logupload.lua otapredownload wanip_check.sh; d
 
 rm -f $FSDIR/etc/hotplug.d/iface/*wanip_check
 
-sed -i '/start_service(/a return 0' $FSDIR/etc/init.d/messagingagent.sh
+for f in wan_check messagingagent.sh; do
+	sed -i '/start_service(/a return 0' $FSDIR/etc/init.d/$f
+done
 
 # cron jobs are mostly non-OpenWRT stuff
 for f in $FSDIR/etc/crontabs/*; do


### PR DESCRIPTION
When I set the router to access point mode, my pihole was logging dns requests to api.miwifi.com every 8 seconds. I found the cause to be the `wan_check` service being manually started by `/usr/sbin/ap_mode.sh`. I fixed it by adding a return statement in the beginning of the start_service method.